### PR TITLE
Add Prettier VSCode integration 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "mikestead.dotenv",
+    "dbaeumer.vscode-eslint",
+    "christian-kohler.path-intellisense",
+    "christian-kohler.npm-intellisense",
+    "esbenp.prettier-vscode",
+    "jpoissonnier.vscode-styled-components"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.rulers": [80],
+  "editor.tabSize": 2,
+  "search.exclude": {
+    "**/node_modules": true
+  },
+  "files.exclude": {
+    "**/.git": true
+  },
+  "[json]": {
+    "editor.formatOnSave": false
+  },
+  "editor.formatOnSave": true
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
     ]
   },
   "license": "MIT",
+  "prettier": {
+    "bracketSpacing": true,
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
   "dependencies": {
     "classnames": "^2.2.5",
     "eslint-plugin-react": "^7.6.1",


### PR DESCRIPTION
Prettier + VSCode-enabled fix on save: there's really no going back once its turned on... Makes everything easier, and especially copy / paste / moving code, since it will automatically format badly-fomatted markup, etc. 

Also added a few nice VSCode plugins including ESlint, which will fix errors that it can automatically. 