### PR TITLE
Handles new pagination limits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "editor.rulers": [80],
+  "editor.rulers": [
+    80
+  ],
   "editor.tabSize": 2,
   "search.exclude": {
     "**/node_modules": true
@@ -10,5 +12,4 @@
   "[json]": {
     "editor.formatOnSave": false
   },
-  "editor.formatOnSave": true
 }


### PR DESCRIPTION
This took longer than I want but stops the weirdness for now. This:

1. Fetches the channel
2. Gets the total number of pages
3. Serially fetches the rest of the pages one by one until it reaches the end
4. Returns the new channel

