### PR TITLE
Fix handlePlayback functionality

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -110,7 +110,7 @@ class Main extends Component {
     } = this.state
     if (currentRoute === '/playlist/:playlistSlug' && !currentTrack) {
       const item = currentOpenPlaylist.contents[0]
-      this.handleSongSelection(item, false)
+      this.handleSongUserSelection(item)
     } else if (currentRoute === '/playlist/:playlistSlug' || currentTrack) {
       isPlaying ? this.pause() : this.play()
     }


### PR DESCRIPTION
# Overview
After cloning and starting the app as instructed in the [README](https://github.com/broskoski/mac.are.na/blob/master/README.md), I found that I was unable to play any tracks without hitting an error due to `Main.js` [calling an undefined function](https://github.com/broskoski/mac.are.na/blob/master/src/Main.js#L113) when the play button was toggled without a current track.  

I'm unsure if the switch from `handleSongSelection` to `handleSongUserSelection` is ideal, but it fixes the issue as `handleSongSelection` does not appear to be defined elsewhere.

# Changes

- Use `handleSongUserSelection` over the undefined `handleSongSelection`.

